### PR TITLE
Изменения уровня доступа objectMapper с private на protected 

### DIFF
--- a/src/main/java/com/bazarnazar/pgjson/PGJsonObject.java
+++ b/src/main/java/com/bazarnazar/pgjson/PGJsonObject.java
@@ -19,7 +19,7 @@ import java.sql.Types;
  */
 public class PGJsonObject implements UserType {
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    protected static final ObjectMapper objectMapper = new ObjectMapper();
 
     static {
         objectMapper.configure(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES, false);


### PR DESCRIPTION
Это нужно для удобной возможности расширения возможностей данного класса.
В моем случае это нужно для 2 вещей:
1. Изменение конфигурации  objectMapper
2. Переопределение методов nullSafeGet и deepCopy для возвращения мапы в виде Map<String, SomeType>, т.к. стандартный вариант работает не совсем корректно
